### PR TITLE
Ensure references to models with self-referential foreign keys work

### DIFF
--- a/src/devdata/strategies.py
+++ b/src/devdata/strategies.py
@@ -90,6 +90,9 @@ class QuerySetStrategy(Exportable, Strategy):
             if not field.related_model:
                 continue
 
+            if field.related_model == model:
+                continue
+
             app_model_label = to_app_model_label(field.related_model)
             restricted_pks[app_model_label] = get_exported_pks_for_model(
                 dest,
@@ -114,7 +117,6 @@ class QuerySetStrategy(Exportable, Strategy):
                 x
                 for x in model._meta.fields
                 if x.related_model == restrict_model
-                if x.related_model != model
             ]
 
             queryset = queryset.filter(

--- a/tests/test_circular_fk.py
+++ b/tests/test_circular_fk.py
@@ -1,0 +1,57 @@
+from test_infrastructure import DevdataTestBase
+from turtles.models import Turtle, World
+
+
+class TestCircularFK(DevdataTestBase):
+    def get_original_data(self):
+        return [
+            {
+                "model": "turtles.Turtle",
+                "strategy": "default",
+                "pk": 1,
+                "fields": {"standing_on_id": None},
+            },
+            {
+                "model": "turtles.Turtle",
+                "strategy": "default",
+                "pk": 2,
+                "fields": {"standing_on_id": 1},
+            },
+            {
+                "model": "turtles.Turtle",
+                "strategy": "default",
+                "pk": 3,
+                "fields": {"standing_on_id": 2},
+            },
+            {
+                "model": "turtles.Turtle",
+                "strategy": "default",
+                "pk": 4,
+                "fields": {"standing_on_id": 2},
+            },
+            {
+                "model": "turtles.World",
+                "strategy": "default",
+                "pk": 9,
+                "fields": {"riding_on_id": 3},
+            },
+            {
+                "model": "turtles.World",
+                "strategy": "default",
+                "pk": 13,
+                "fields": {"riding_on_id": 4},
+            },
+        ]
+
+    def assert_on_exported_data(self, exported_data):
+        exported_turtle_pks = self.exported_pks(exported_data, "turtles.Turtle")
+        assert exported_turtle_pks == set((1, 2, 3, 4))
+
+        exported_workd_pks = self.exported_pks(exported_data, "turtles.World")
+        assert exported_workd_pks == set((9, 13))
+
+    def assert_on_imported_data(self):
+        assert set(Turtle.objects.values_list("pk", flat=True)) == set(
+            (1, 2, 3, 4)
+        )
+        assert set(World.objects.values_list("pk", flat=True)) == set((9, 13))

--- a/tests/test_infrastructure/base.py
+++ b/tests/test_infrastructure/base.py
@@ -80,7 +80,10 @@ class DevdataTestBase:
 
         for obj in objects:
             for field, model in fk_fields:
-                if obj["fields"][field] in lookup[model]:
+                if (
+                    obj["fields"][field] is None
+                    or obj["fields"][field] in lookup[model]
+                ):
                     yield obj
 
     # Test structure

--- a/tests/test_infrastructure/base.py
+++ b/tests/test_infrastructure/base.py
@@ -27,6 +27,8 @@ ALL_TEST_STRATEGIES = (
     ("photofeed.Photo", "default"),
     ("photofeed.Like", "latest"),
     ("photofeed.View", "random"),
+    ("turtles.Turtle", "default"),
+    ("turtles.World", "default"),
     ("auth.User", "internal"),
     ("auth.User", "test_users"),
 )

--- a/tests/testsite/testsite/settings/django.py
+++ b/tests/testsite/testsite/settings/django.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
     "devdata",
     "polls",
     "photofeed",
+    "turtles",
 ]
 
 MIDDLEWARE = [

--- a/tests/testsite/turtles/models.py
+++ b/tests/testsite/turtles/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class Turtle(models.Model):
+    standing_on = models.ForeignKey("self", on_delete=models.PROTECT, null=True)
+
+
+class World(models.Model):
+    riding_on = models.ForeignKey(Turtle, on_delete=models.PROTECT)


### PR DESCRIPTION
While models with self-referential foreign keys worked previously, models which had foreign keys to them did not. This fixes the check for a self-referential foreign key such that it doesn't pollute the pks cache while exporting itself, thus allowing the exports of models with foreign keys to such self-referential models. 