### PR TITLE
Extend tested Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
           python-version: 3.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         django-version: [2.2, 3.0, 3.1, 3.2]
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
-        django-version: [2.2, 3.0, 3.1, 3.2]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        django-version: ["2.2", "3.0", "3.1", "3.2"]
         exclude:
           # Python 3.10 is not supported until Django 3.2
           - python-version: "3.10"
-            django-version: 2.2
+            django-version: "2.2"
           - python-version: "3.10"
-            django-version: 3.0
+            django-version: "3.0"
           - python-version: "3.10"
-            django-version: 3.1
+            django-version: "3.1"
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
         django-version: [2.2, 3.0, 3.1, 3.2]
+        exclude:
+          # Python 3.10 is not supported until Django 3.2
+          - python-version: "3.10"
+            django-version: 2.2
+          - python-version: "3.10"
+            django-version: 3.0
+          - python-version: "3.10"
+            django-version: 3.1
 
     services:
       postgres:

--- a/poetry.lock
+++ b/poetry.lock
@@ -294,7 +294,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "6.2.2"
+version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -307,7 +307,7 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0.0a1"
+pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
 toml = "*"
 
@@ -675,8 +675,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.2.2-py3-none-any.whl", hash = "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"},
-    {file = "pytest-6.2.2.tar.gz", hash = "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9"},
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 pytest-check = [
     {file = "pytest_check-1.0.1-py2.py3-none-any.whl", hash = "sha256:037d1a0777c7ebbe7b4e17d09ca7956793aa86d36bea851c0edeed361d0928bc"},

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 isolated_build = true
-envlist = py{37,38,39}-django{22,30,31,32}
+envlist = py{37,38,39,310}-django{22,30,31,32}
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 django-version =


### PR DESCRIPTION
~Builds on https://github.com/danpalmer/django-devdata/pull/8 to pick up the CI fixes which that includes.~

It looks like Django 4 will need some actual code changes, or at least test setup changes. This PR therefore only looks at Python versions.

Also included here is a fix such that the Django "3.0" tests actually only test `3.0` and not everything.