### PR TITLE
Support database sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,26 @@ In our experience most models can be exported with just the un-customised
 `QuerySetStrategy`, some will need to use other pre-provided strategies, and
 a small number will need custom exporters based on the classes provided.
 
+##### Extra Strategies
+
+Sometimes it can be useful to export and import data from the database which
+lives outside the tables which Django manages via models.
+
+The "extra" strategies provide hooks which support transferring these data.
+
+Classes are provided to inherit from for customising this behaviour:
+
+- `ExtraExport` – defines how to get data out of the database.
+- `ExtraImport` – defines how to get data into a database.
+
+The API necessary for classes to implement is small and reminiscent of those for
+`Strategy` and `Exportable`.
+
+The following "extra" strategies are provided out of the box:
+
+- `PostgresSequences` – transfers data about Postgres sequences which are not
+  attached to tables.
+
 #### Anonymisers
 
 Anonymisers are configured by field name, and by model and field name.
@@ -201,6 +221,14 @@ django-devdata default settings, with documentation on usage.
 # A mapping of app model label to list of strategies to be used.
 DEVDATA_STRATEGIES = ...
 # {'auth.User': [QuerySetStrategy(name='all')], 'sessions.Session': []}
+
+# Optional
+# A list of strategies for transferring data about a database which are not
+# captured in the tables themselves.
+DEVDATA_EXTRA_STRATEGIES = ...
+# [
+#   ('devdata.extras.PostgresSequences', {}),
+# ]
 
 # Optional
 # A mapping of field name to an anonymiser to be used for all fields with that

--- a/src/devdata/extras.py
+++ b/src/devdata/extras.py
@@ -1,0 +1,63 @@
+import json
+import textwrap
+from pathlib import Path
+from typing import Callable, Dict, Set, Tuple
+
+from django.db import connections
+
+Logger = Callable[[object], None]
+
+
+class ExtraImport:
+    """
+    Base extra defining how to get data into a fresh database.
+    """
+
+    depends_on = ()  # type: Tuple[str, ...]
+
+    def __init__(self) -> None:
+        pass
+
+    def import_data(self, django_dbname: str, src: Path) -> None:
+        """Load data into newly created database."""
+        raise NotImplementedError
+
+
+class ExtraExport:
+    """
+    Base extra defining how to get data out of an existing .
+    """
+
+    seen_names = set()  # type: Set[Tuple[str, str]]
+
+    def __init__(self, *args, name, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.name = name
+
+    def export_data(
+        self,
+        django_dbname: str,
+        dest: Path,
+        no_update: bool = False,
+        log: Logger = lambda x: None,
+    ) -> None:
+        """
+        Export the data to a directory on disk. `no_update` indicates not to
+        update if there is any data already existing locally.
+        """
+        pass
+
+    def data_file(self, dest: Path) -> Path:
+        return dest / f"{self.name}.json"
+
+    def ensure_dir_exists(self, dest: Path) -> None:
+        unique_key = self.name
+        if unique_key in self.seen_names:
+            raise ValueError(
+                "Exportable strategy names must be unique per model so that "
+                "exports do not collide.",
+            )
+        self.seen_names.add(unique_key)
+
+        dest.mkdir(parents=True, exist_ok=True)

--- a/src/devdata/extras.py
+++ b/src/devdata/extras.py
@@ -25,7 +25,7 @@ class ExtraImport:
 
 class ExtraExport:
     """
-    Base extra defining how to get data out of an existing .
+    Base extra defining how to get data out of an existing database.
     """
 
     seen_names = set()  # type: Set[Tuple[str, str]]

--- a/src/devdata/extras.py
+++ b/src/devdata/extras.py
@@ -61,3 +61,125 @@ class ExtraExport:
         self.seen_names.add(unique_key)
 
         dest.mkdir(parents=True, exist_ok=True)
+
+
+class PostgresSequences(ExtraExport, ExtraImport):
+    def __init__(self, *args, name="postgres-sequences", **kwargs):
+        super().__init__(*args, name=name, **kwargs)
+
+    def export_data(
+        self,
+        django_dbname: str,
+        dest: Path,
+        no_update: bool = False,
+        log: Logger = lambda x: None,
+    ) -> None:
+        data_file = self.data_file(dest)
+
+        if no_update and data_file.exists():
+            return
+
+        columns = (
+            "sequencename",
+            "data_type",
+            "start_value",
+            "min_value",
+            "max_value",
+            "increment_by",
+            "cycle",
+            "cache_size",
+            "last_value",
+        )
+
+        with connections[django_dbname].cursor() as cursor:
+            cursor.execute(
+                """
+                    SELECT
+                        {columns}
+                    FROM
+                        pg_sequences
+                    WHERE
+                        sequencename NOT IN (
+                            SELECT
+                                seq.relname
+                            FROM
+                                pg_class AS seq
+                            LEFT JOIN
+                                pg_depend
+                            ON
+                                seq.relfilenode = pg_depend.objid
+                            JOIN
+                                pg_attribute AS attr
+                            ON
+                                attr.attnum = pg_depend.refobjsubid
+                                AND attr.attrelid = pg_depend.refobjid
+                            WHERE
+                                seq.relkind = 'S'
+                        );
+                """.format(
+                    columns=", ".join(columns),
+                ),
+            )
+            sequences_state = [
+                dict(zip(columns, row)) for row in cursor.fetchall()
+            ]
+
+            # Cope with the 'last_value' having not been populated in this
+            # session. The following query is (I think) only supported in
+            # Postgres 11.2+, however since Postgres 10 is about to be EOL
+            # (November 2022) it doesn't seem worth the effort to support older
+            # versions.
+            for sequence_state in sequences_state:
+                if sequence_state["last_value"] is None:
+                    name = sequence_state["sequencename"]
+                    cursor.execute(f"SELECT last_value FROM {name}")
+                    (sequence_state["last_value"],) = cursor.fetchone()
+
+        with data_file.open("w") as f:
+            json.dump(sequences_state, f, indent=4)
+
+    def import_data(self, django_dbname: str, src: Path) -> None:
+        with self.data_file(src).open() as f:
+            sequences = json.load(f)
+
+        def check_simple_value(mapping: Dict[str, str], *, key: str) -> str:
+            value = mapping[key]
+            if not value.replace("_", "").isalnum():
+                raise ValueError(f"{key} is not alphanumeric")
+            return value
+
+        with connections[django_dbname].cursor() as cursor:
+            for sequence in sequences:
+                # Sequence name & data type need to be inline (i.e: can't be
+                # passed as data), so provide some safety here.
+                name = check_simple_value(sequence, key="sequencename")
+                data_type = check_simple_value(sequence, key="data_type")
+
+                query = textwrap.dedent(
+                    f"""
+                    CREATE SEQUENCE {name}
+                    AS {data_type}
+                    INCREMENT BY %s
+                    MINVALUE %s
+                    MAXVALUE %s
+                    START %s
+                    CACHE %s
+                """
+                )
+                params = [
+                    sequence["increment_by"],
+                    sequence["min_value"],
+                    sequence["max_value"],
+                    sequence["last_value"],
+                    sequence["cache_size"],
+                ]
+
+                if sequence["cycle"]:
+                    query += "CYCLE "
+                else:
+                    query += "NO CYCLE "
+
+                cursor.execute(query, params)
+
+                # Move on from the last value (which has already been used)
+                cursor.execute("SELECT nextval(%s)", [name])

--- a/src/devdata/management/commands/devdata_export.py
+++ b/src/devdata/management/commands/devdata_export.py
@@ -5,7 +5,12 @@ from django.apps import apps
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 from django.db.utils import DEFAULT_DB_ALIAS
 
-from ...engine import export_data, export_migration_state, validate_strategies
+from ...engine import (
+    export_data,
+    export_migration_state,
+    export_extras,
+    validate_strategies,
+)
 
 
 class Command(BaseCommand):
@@ -51,3 +56,4 @@ class Command(BaseCommand):
 
         export_migration_state(database, dest_dir)
         export_data(database, dest_dir, only, no_update)
+        export_extras(database, dest_dir)

--- a/src/devdata/management/commands/devdata_import.py
+++ b/src/devdata/management/commands/devdata_import.py
@@ -9,6 +9,7 @@ from ...engine import (
     import_cleanup,
     import_data,
     import_schema,
+    import_extras,
     validate_strategies,
 )
 from ...settings import settings
@@ -58,4 +59,5 @@ class Command(BaseCommand):
 
         import_schema(src, database)
         import_data(src, database)
+        import_extras(src, database)
         import_cleanup(src, database)

--- a/src/devdata/settings.py
+++ b/src/devdata/settings.py
@@ -10,6 +10,15 @@ DEFAULT_MODEL_ANONYMISERS = {}
 DEFAULT_FAKER_LOCALES = ["en_US"]
 
 
+def import_strategy(strategy):
+    try:
+        klass_path, kwargs = strategy
+        klass = import_string(klass_path)
+        return klass(**kwargs)
+    except (ValueError, TypeError, IndexError):
+        return strategy
+
+
 class Settings:
     @property
     def strategies(self):
@@ -36,12 +45,9 @@ class Settings:
                     ret[app_model_label] = [default_strategy]
             else:
                 for strategy in strategies:
-                    try:
-                        klass_path, kwargs = strategy
-                        klass = import_string(klass_path)
-                        ret[app_model_label].append(klass(**kwargs))
-                    except (ValueError, TypeError, IndexError):
-                        ret[app_model_label].append(strategy)
+                    ret[app_model_label].append(
+                        import_strategy(strategy),
+                    )
 
         return ret
 

--- a/src/devdata/settings.py
+++ b/src/devdata/settings.py
@@ -52,6 +52,13 @@ class Settings:
         return ret
 
     @property
+    def extra_strategies(self):
+        return [
+            import_strategy(x)
+            for x in getattr(django_settings, "DEVDATA_EXTRA_STRATEGIES", ())
+        ]
+
+    @property
     def field_anonymisers(self):
         return getattr(
             django_settings,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,46 @@
+import json
 import shutil
 from pathlib import Path
 
 import pytest
 
+ALL_TEST_STRATEGIES = (
+    ("admin.LogEntry", "default"),
+    ("auth.Permission", "replaced"),
+    ("auth.Group_permissions", "default"),
+    ("auth.Group", "default"),
+    ("auth.User_groups", "default"),
+    ("auth.User_user_permissions", "default"),
+    ("contenttypes.ContentType", "replaced"),
+    ("sessions.Session", "default"),
+    ("polls.Question", "default"),
+    ("polls.Choice", "default"),
+    ("photofeed.Photo", "default"),
+    ("photofeed.Like", "latest"),
+    ("photofeed.View", "random"),
+    ("turtles.Turtle", "default"),
+    ("turtles.World", "default"),
+    ("auth.User", "internal"),
+    ("auth.User", "test_users"),
+)
+
 
 @pytest.fixture()
 def test_data_dir():
     return Path(__file__).parent / "test-data-tmp"
+
+
+@pytest.fixture()
+def default_export_data(test_data_dir):
+    # Write out defaults of empty exports for everything first, not all
+    # tests will use all models.
+    empty_model = json.dumps([])
+    for model, strategy in ALL_TEST_STRATEGIES:
+        path = test_data_dir / model / f"{strategy}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(empty_model)
+
+    (test_data_dir / "migrations.json").write_text(empty_model)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+from django.db import connection
 
 ALL_TEST_STRATEGIES = (
     ("admin.LogEntry", "default"),
@@ -42,8 +43,18 @@ def default_export_data(test_data_dir):
 
     (test_data_dir / "migrations.json").write_text(empty_model)
 
+    (test_data_dir / "postgres-sequences.json").write_text(empty_model)
+
 
 @pytest.fixture(autouse=True)
 def cleanup_test_data(test_data_dir):
     yield
     shutil.rmtree(test_data_dir, ignore_errors=True)
+
+
+@pytest.fixture()
+def cleanup_database():
+    yield
+
+    with connection.cursor() as cursor:
+        cursor.execute("DROP SEQUENCE IF EXISTS foo")

--- a/tests/test_infrastructure/base.py
+++ b/tests/test_infrastructure/base.py
@@ -92,11 +92,12 @@ class DevdataTestBase:
                     exported_data["migrations"] = json.load(f)
             else:
                 exported_data[child.name] = {}
-                for strategy_file in child.iterdir():
-                    with strategy_file.open() as f:
-                        exported_data[child.name][
-                            strategy_file.stem
-                        ] = json.load(f)
+                if child.is_dir():
+                    for strategy_file in child.iterdir():
+                        with strategy_file.open() as f:
+                            exported_data[child.name][
+                                strategy_file.stem
+                            ] = json.load(f)
 
         self.assert_on_exported_data(exported_data)
 

--- a/tests/test_infrastructure/base.py
+++ b/tests/test_infrastructure/base.py
@@ -13,26 +13,6 @@ from .utils import assert_ran_successfully, run_command
 
 TestObject = Dict[str, Any]
 
-ALL_TEST_STRATEGIES = (
-    ("admin.LogEntry", "default"),
-    ("auth.Permission", "replaced"),
-    ("auth.Group_permissions", "default"),
-    ("auth.Group", "default"),
-    ("auth.User_groups", "default"),
-    ("auth.User_user_permissions", "default"),
-    ("contenttypes.ContentType", "replaced"),
-    ("sessions.Session", "default"),
-    ("polls.Question", "default"),
-    ("polls.Choice", "default"),
-    ("photofeed.Photo", "default"),
-    ("photofeed.Like", "latest"),
-    ("photofeed.View", "random"),
-    ("turtles.Turtle", "default"),
-    ("turtles.World", "default"),
-    ("auth.User", "internal"),
-    ("auth.User", "test_users"),
-)
-
 
 @pytest.mark.django_db(transaction=True)
 class DevdataTestBase:
@@ -120,15 +100,12 @@ class DevdataTestBase:
 
         self.assert_on_exported_data(exported_data)
 
-    def test_import(self, test_data_dir, django_db_blocker):
-        # Write out defaults of empty exports for everything first, not all
-        # tests will use all models.
-        empty_model = json.dumps([])
-        for model, strategy in ALL_TEST_STRATEGIES:
-            path = test_data_dir / model / f"{strategy}.json"
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(empty_model)
-
+    def test_import(
+        self,
+        test_data_dir,
+        default_export_data,
+        django_db_blocker,
+    ):
         # Write out data to the filesystem as if it had been exported
         data = collections.defaultdict(
             lambda: collections.defaultdict(list)
@@ -149,8 +126,6 @@ class DevdataTestBase:
                         list(self._filter_exported(exported_pks, objects))
                     )
                 )
-
-        (test_data_dir / "migrations.json").write_text(empty_model)
 
         # Ensure all database connections are closed before we attempt to import
         # as this will need to drop the database.

--- a/tests/test_sequences_extra.py
+++ b/tests/test_sequences_extra.py
@@ -1,0 +1,74 @@
+import json
+
+import pytest
+from django.db import connection, connections
+from test_infrastructure import assert_ran_successfully, run_command
+
+
+@pytest.mark.django_db(transaction=True)
+class TestPostgresSequences:
+    SAMPLE_DATA = {
+        "sequencename": "foo",
+        "data_type": "bigint",
+        "start_value": 6,
+        "min_value": 6,
+        "max_value": 9223372036854775807,
+        "increment_by": 4,
+        "cycle": False,
+        "cache_size": 1,
+        "last_value": 14,
+    }
+
+    def test_export(self, test_data_dir, cleanup_database):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                CREATE SEQUENCE foo
+                AS bigint
+                INCREMENT BY 4
+                MINVALUE 6
+                """,
+            )
+            cursor.execute("SELECT nextval('foo')")
+            cursor.execute("SELECT nextval('foo')")
+            cursor.execute("SELECT nextval('foo')")
+            (value,) = cursor.fetchone()
+            assert value == 14
+
+        # Run the export
+        process = run_command(
+            "devdata_export",
+            test_data_dir.name,
+        )
+        assert_ran_successfully(process)
+
+        # Read in the exported data
+        exported_data = json.loads(
+            (test_data_dir / "postgres-sequences.json").read_text(),
+        )
+
+        assert exported_data == [self.SAMPLE_DATA]
+
+    def test_import(self, test_data_dir, default_export_data, cleanup_database):
+        test_data_dir.mkdir(parents=True, exist_ok=True)
+        (test_data_dir / "postgres-sequences.json").write_text(
+            json.dumps([self.SAMPLE_DATA]),
+        )
+
+        # Ensure all database connections are closed before we attempt to import
+        # as this will need to drop the database.
+        for conn in connections.all():
+            conn.close()
+
+        # Run the import
+        process = run_command(
+            "devdata_import",
+            test_data_dir.name,
+            "--no-input",
+        )
+        assert_ran_successfully(process)
+
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT nextval('foo')")
+            (value,) = cursor.fetchone()
+            assert value == 18

--- a/tests/test_sequences_extra.py
+++ b/tests/test_sequences_extra.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from django.db import connection, connections
+from django.db.migrations.recorder import MigrationRecorder
 from test_infrastructure import assert_ran_successfully, run_command
 
 
@@ -20,6 +21,9 @@ class TestPostgresSequences:
     }
 
     def test_export(self, test_data_dir, cleanup_database):
+        for conn in connections.all():
+            MigrationRecorder(conn).ensure_schema()
+
         with connection.cursor() as cursor:
             cursor.execute(
                 """
@@ -50,6 +54,9 @@ class TestPostgresSequences:
         assert exported_data == [self.SAMPLE_DATA]
 
     def test_export_unused_sequence(self, test_data_dir, cleanup_database):
+        for conn in connections.all():
+            MigrationRecorder(conn).ensure_schema()
+
         with connection.cursor() as cursor:
             cursor.execute(
                 """

--- a/tests/testsite/testsite/settings/devdata.py
+++ b/tests/testsite/testsite/settings/devdata.py
@@ -76,3 +76,7 @@ DEVDATA_STRATEGIES = {
         ExactQuerySetStrategy(name="test_users", pks=(102,)),
     ],
 }
+
+DEVDATA_EXTRA_STRATEGIES = [
+    ("devdata.extras.PostgresSequences", {}),
+]


### PR DESCRIPTION
This aims to fix https://github.com/danpalmer/django-devdata/issues/1 by introducing a generic mechanism for exporting & importing non-model data. That is then used to support sequences from Postgres databases.

In theory other databases could be supported, though would likely need their own implementations given how this finds the sequences to export.

I've tested this locally using a reasonably sized test database.