### PR TITLE
Support different reset modes during import

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Exporting, anonymising, and importing, are all configurable, and
 
 #### Exporting
 
+``` console
+$ python manage.py devdata_export [dest] [app_label.ModelName ...]
+```
+
 This step allows a sync strategy to persist some data that will be used to
 create a new development database. For example, the `QuerySetStrategy` can
 export data from a table to a filesystem for later import.
@@ -124,6 +128,10 @@ step.
 
 #### Importing
 
+``` console
+$ python manage.py devdata_import [src]
+```
+
 This step is responsible for preparing the database and filling it. If any
 exporting strategies have been used those must have run first, or their outputs
 must have been downloaded if they are being shared/hosted somewhere.
@@ -131,6 +139,10 @@ must have been downloaded if they are being shared/hosted somewhere.
 Factory-based strategies generate data during this process.
 
 ##### Reset modes
+
+``` console
+$ python manage.py devdata_import --reset-mode=$MODE [src]
+```
 
 By default any existing database will be removed, ensuring that a fresh database
 is created for the imported data. This is expected to be the most common case

--- a/README.md
+++ b/README.md
@@ -124,11 +124,28 @@ step.
 
 #### Importing
 
-This step is responsible for creating a new database and filling it. If any
+This step is responsible for preparing the database and filling it. If any
 exporting strategies have been used those must have run first, or their outputs
 must have been downloaded if they are being shared/hosted somewhere.
 
 Factory-based strategies generate data during this process.
+
+##### Reset modes
+
+By default any existing database will be removed, ensuring that a fresh database
+is created for the imported data. This is expected to be the most common case
+for local development, but may not always be suitable.
+
+The following modes are offered:
+
+- `drop-database`: the default; drops the database & re-creates it.
+- `drop-tables`: drops the tables the Django codebase is aware of, useful if the
+  Django database user doesn't have access to drop the entire database.
+- `none`: no attempt to reset the database, useful if the user has already
+  manually configured the database or otherwise wants more control over setup.
+
+See the docstrings in [`src/devdata/reset_modes.py`](src/devdata/reset_modes.py)
+for more details.
 
 ## Customising
 

--- a/src/devdata/engine.py
+++ b/src/devdata/engine.py
@@ -13,7 +13,6 @@ from .utils import (
     disable_migrations,
     get_all_models,
     migrations_file_path,
-    nodb_cursor,
     progress,
     sort_model_strategies,
     to_app_model_label,
@@ -116,22 +115,7 @@ def export_extras(django_dbname, dest, no_update=False):
 
 
 def import_schema(src, django_dbname):
-    db_conf = settings.DATABASES[django_dbname]
-    pg_dbname = db_conf["NAME"]
-
     connection = connections[django_dbname]
-
-    with nodb_cursor(connection) as cursor:
-        cursor.execute("DROP DATABASE IF EXISTS {}".format(pg_dbname))
-
-        creator = connection.creation
-        creator._execute_create_test_db(
-            cursor,
-            {
-                "dbname": pg_dbname,
-                "suffix": creator.sql_table_creation_suffix(),
-            },
-        )
 
     with disable_migrations():
         call_command(

--- a/src/devdata/extras.py
+++ b/src/devdata/extras.py
@@ -155,6 +155,19 @@ class PostgresSequences(ExtraExport, ExtraImport):
                 name = check_simple_value(sequence, key="sequencename")
                 data_type = check_simple_value(sequence, key="data_type")
 
+                # Support reset modes which don't drop the database. At some
+                # point it might be nice to be able to hook into the reset mode
+                # to remove sequences too, however that's likely complicated and
+                # it's easy enough to handle here.
+                #
+                # Sequences don't nicely fit into one of just schema or data,
+                # they're somewhat inherently both. Given that Django's
+                # "loaddata" over-writes existing rows in tables, it seems
+                # reasonable to do something similar for sequences -- even if
+                # that means we actually drop the sequence and fully re-create
+                # it.
+                cursor.execute(f"DROP SEQUENCE IF EXISTS {name}")
+
                 query = textwrap.dedent(
                     f"""
                     CREATE SEQUENCE {name}

--- a/src/devdata/extras.py
+++ b/src/devdata/extras.py
@@ -64,6 +64,18 @@ class ExtraExport:
 
 
 class PostgresSequences(ExtraExport, ExtraImport):
+    """
+    Export & import Postgres sequences.
+
+    This provides support for reproducing sequences of the same type and at the
+    same value in an imported database.
+
+    During import any existing sequence of the same name is silently removed and
+    replaced. This simplifies the interaction with each of the possible reset
+    modes and approximately matches how `loaddata` treats importing rows with
+    matching primary keys.
+    """
+
     def __init__(self, *args, name="postgres-sequences", **kwargs):
         super().__init__(*args, name=name, **kwargs)
 

--- a/src/devdata/management/commands/devdata_import.py
+++ b/src/devdata/management/commands/devdata_import.py
@@ -12,7 +12,7 @@ from ...engine import (
     import_extras,
     validate_strategies,
 )
-from ...reset_modes import MODES
+from ...reset_modes import MODES, DropDatabaseReset
 from ...settings import settings
 
 
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             choices=MODES.values(),
             type=MODES.__getitem__,
             help="How to ensure the database is empty before importing the new schema (default: %(default)s).",
-            default=MODES["drop"].slug,
+            default=DropDatabaseReset.slug,
         )
         parser.add_argument(
             "--no-input",

--- a/src/devdata/management/commands/devdata_import.py
+++ b/src/devdata/management/commands/devdata_import.py
@@ -50,17 +50,23 @@ class Command(BaseCommand):
         except AssertionError as e:
             raise CommandError(e)
 
-        if not no_input and (
-            input(
-                "You're about to {} {} ({}) from the host {}. "
-                "Are you sure you want to continue? [y/N]: ".format(
-                    reset_mode.description_for_confirmation,
-                    self.style.WARNING(database),
-                    self.style.WARNING(settings.DATABASES[database]["NAME"]),
-                    self.style.WARNING(socket.gethostname()),
-                ),
-            ).lower()
-            != "y"
+        if (
+            not no_input
+            and reset_mode.requires_confirmation
+            and (
+                input(
+                    "You're about to {} {} ({}) from the host {}. "
+                    "Are you sure you want to continue? [y/N]: ".format(
+                        reset_mode.description_for_confirmation,
+                        self.style.WARNING(database),
+                        self.style.WARNING(
+                            settings.DATABASES[database]["NAME"]
+                        ),
+                        self.style.WARNING(socket.gethostname()),
+                    ),
+                ).lower()
+                != "y"
+            )
         ):
             raise CommandError("Aborted")
 

--- a/src/devdata/management/commands/devdata_import.py
+++ b/src/devdata/management/commands/devdata_import.py
@@ -50,23 +50,17 @@ class Command(BaseCommand):
         except AssertionError as e:
             raise CommandError(e)
 
-        if (
-            not no_input
-            and reset_mode.requires_confirmation
-            and (
-                input(
-                    "You're about to {} {} ({}) from the host {}. "
-                    "Are you sure you want to continue? [y/N]: ".format(
-                        reset_mode.description_for_confirmation,
-                        self.style.WARNING(database),
-                        self.style.WARNING(
-                            settings.DATABASES[database]["NAME"]
-                        ),
-                        self.style.WARNING(socket.gethostname()),
-                    ),
-                ).lower()
-                != "y"
-            )
+        if not no_input and (
+            input(
+                "You're about to {} {} ({}) from the host {}. "
+                "Are you sure you want to continue? [y/N]: ".format(
+                    reset_mode.description_for_confirmation,
+                    self.style.WARNING(database),
+                    self.style.WARNING(settings.DATABASES[database]["NAME"]),
+                    self.style.WARNING(socket.gethostname()),
+                ),
+            ).lower()
+            != "y"
         ):
             raise CommandError("Aborted")
 

--- a/src/devdata/reset_modes.py
+++ b/src/devdata/reset_modes.py
@@ -40,6 +40,13 @@ class Reset(abc.ABC):
 
 
 class DropDatabaseReset(Reset):
+    """
+    Drop the entire database and re-create it using Django's test utils.
+
+    This is suitable in cases where Django is configured with a database
+    superuser account, which is likely to be the case in local development.
+    """
+
     slug = "drop-database"
 
     description_for_confirmation = "delete the database"
@@ -64,6 +71,20 @@ class DropDatabaseReset(Reset):
 
 
 class DropTablesReset(Reset):
+    """
+    Drop all the tables which Django knows about.
+
+    This is suitable in cases where the current state of the database can be
+    assumed to be similar enough to the new state that removing the tables alone
+    is sufficient to clear out the data. For databases which support other forms
+    of data (e.g: Postgres sequences decoupled from tables) this mode will not
+    touch those data and the user must ensure they are handled suitably.
+
+    This is expected to be useful in cases where Django is configured with
+    administrative privileges within a database, but may not have access to drop
+    the entire database.
+    """
+
     slug = "drop-tables"
 
     description_for_confirmation = "delete all tables in the database"
@@ -82,6 +103,15 @@ class DropTablesReset(Reset):
 
 
 class NoReset(Reset):
+    """
+    Perform no resetting against the database.
+
+    This is suitable in cases where the user has already manually configured the
+    target database or otherwise wants more control over the setup. The user is
+    responsible for ensuring that the database is in a state ready to have the
+    schema migrated into it.
+    """
+
     slug = "none"
 
     requires_confirmation = False

--- a/src/devdata/reset_modes.py
+++ b/src/devdata/reset_modes.py
@@ -5,6 +5,7 @@ Alternative implementations for ensuring a clean database before import.
 import abc
 
 from django.db import connections
+from django.db.migrations.recorder import MigrationRecorder
 
 from .settings import settings
 from .utils import nodb_cursor
@@ -94,7 +95,12 @@ class DropTablesReset(Reset):
 
         with connection.cursor() as cursor:
             table_names = connection.introspection.table_names(cursor)
+
             models = connection.introspection.installed_models(table_names)
+
+            if MigrationRecorder(connection).has_table():
+                models.add(MigrationRecorder.Migration)
+
             with connection.schema_editor() as editor:
                 for model in models:
                     editor.delete_model(model)

--- a/src/devdata/reset_modes.py
+++ b/src/devdata/reset_modes.py
@@ -93,10 +93,8 @@ class DropTablesReset(Reset):
         connection = connections[django_dbname]
 
         with connection.cursor() as cursor:
-            table_infos = connection.introspection.get_table_list(cursor)
-            models = connection.introspection.installed_models(
-                [x.name for x in table_infos],
-            )
+            table_names = connection.introspection.table_names(cursor)
+            models = connection.introspection.installed_models(table_names)
             with connection.schema_editor() as editor:
                 for model in models:
                     editor.delete_model(model)

--- a/src/devdata/reset_modes.py
+++ b/src/devdata/reset_modes.py
@@ -1,0 +1,59 @@
+"""
+Alternative implementations for ensuring a clean database before import.
+"""
+
+import abc
+
+from django.db import connections
+
+from .settings import settings
+from .utils import nodb_cursor
+
+MODES = {}
+
+
+class Reset(abc.ABC):
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        MODES[cls.slug] = cls()
+
+    @property
+    @abc.abstractclassmethod
+    def slug(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractclassmethod
+    def description_for_confirmation(self) -> str:
+        raise NotImplementedError
+
+    def reset_database(self, django_dbname: str) -> None:
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        # Use the slug as the str for easier integration into the CLI
+        return self.slug
+
+
+class DropDatabaseReset(Reset):
+    slug = "drop"
+
+    description_for_confirmation = "delete the database"
+
+    def reset_database(self, django_dbname: str) -> None:
+        db_conf = settings.DATABASES[django_dbname]
+        pg_dbname = db_conf["NAME"]
+
+        connection = connections[django_dbname]
+
+        with nodb_cursor(connection) as cursor:
+            cursor.execute("DROP DATABASE IF EXISTS {}".format(pg_dbname))
+
+            creator = connection.creation
+            creator._execute_create_test_db(
+                cursor,
+                {
+                    "dbname": pg_dbname,
+                    "suffix": creator.sql_table_creation_suffix(),
+                },
+            )

--- a/src/devdata/reset_modes.py
+++ b/src/devdata/reset_modes.py
@@ -23,6 +23,10 @@ class Reset(abc.ABC):
         raise NotImplementedError
 
     @property
+    def requires_confirmation(self) -> bool:
+        return True
+
+    @property
     @abc.abstractclassmethod
     def description_for_confirmation(self) -> str:
         raise NotImplementedError
@@ -57,3 +61,14 @@ class DropDatabaseReset(Reset):
                     "suffix": creator.sql_table_creation_suffix(),
                 },
             )
+
+
+class NoReset(Reset):
+    slug = "none"
+
+    requires_confirmation = False
+
+    description_for_confirmation = ""
+
+    def reset_database(self, django_dbname: str) -> None:
+        pass

--- a/src/devdata/reset_modes.py
+++ b/src/devdata/reset_modes.py
@@ -24,10 +24,6 @@ class Reset(abc.ABC):
         raise NotImplementedError
 
     @property
-    def requires_confirmation(self) -> bool:
-        return True
-
-    @property
     @abc.abstractclassmethod
     def description_for_confirmation(self) -> str:
         raise NotImplementedError
@@ -118,9 +114,7 @@ class NoReset(Reset):
 
     slug = "none"
 
-    requires_confirmation = False
-
-    description_for_confirmation = ""
+    description_for_confirmation = "merge into the existing database"
 
     def reset_database(self, django_dbname: str) -> None:
         pass

--- a/src/devdata/reset_modes.py
+++ b/src/devdata/reset_modes.py
@@ -69,7 +69,7 @@ class DropDatabaseReset(Reset):
 
 class DropTablesReset(Reset):
     """
-    Drop all the tables which Django knows about.
+    Drop all the tables which Django knows about, including migration history.
 
     This is suitable in cases where the current state of the database can be
     assumed to be similar enough to the new state that removing the tables alone
@@ -80,6 +80,10 @@ class DropTablesReset(Reset):
     This is expected to be useful in cases where Django is configured with
     administrative privileges within a database, but may not have access to drop
     the entire database.
+
+    Note: this will not touch other database entities (e.g: Postgres sequences &
+    views) which may be present but are not managed by Django models -- even if
+    they were created by running migrations (e.g: via `RunSQL`).
     """
 
     slug = "drop-tables"
@@ -110,6 +114,14 @@ class NoReset(Reset):
     target database or otherwise wants more control over the setup. The user is
     responsible for ensuring that the database is in a state ready to have the
     schema migrated into it.
+
+    Notes:
+     * As `loaddata` is used to import data, this mode may result in a merging
+       of the new and existing data (if there is any).
+     * Django's migrations table does not have any uniqueness constraints,
+       meaning that even identical rows may be reinserted and resulting in
+       apparently duplicate rows in that table. The effects of this on Django
+       are unknown. You have been warned.
     """
 
     slug = "none"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,14 @@
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from django.db import connections
 from polls.models import Choice, Question
 from test_infrastructure import DevdataTestBase
+from test_infrastructure.utils import assert_ran_successfully, run_command
+
+from devdata.reset_modes import MODES
 
 
 class TestPollsBasic(DevdataTestBase):
@@ -70,3 +79,53 @@ class TestPollsBasic(DevdataTestBase):
         ) == ["Test 1", "Test 2"]
         assert Choice.objects.count() == 3
         assert Question.objects.get(pk=101).choice_set.count() == 2
+
+    @pytest.mark.parametrize(
+        "reset_mode",
+        [x for x in MODES.keys() if x != "none"],
+    )
+    def test_import_over_existing_data(
+        self,
+        reset_mode,
+        test_data_dir,
+        default_export_data,
+        django_db_blocker,
+    ):
+        self.dump_data_for_import(self.get_original_data(), test_data_dir)
+
+        question = Question.objects.create(
+            question_text="Do you like jam?",
+            pub_date=datetime.datetime.now(datetime.timezone.utc),
+        )
+        Choice.objects.create(
+            question=question,
+            choice_text="Yes",
+            votes=2,
+        )
+        Choice.objects.create(
+            pk=103,  # conflicts with data to be imported
+            question=question,
+            choice_text="No",
+            votes=2,
+        )
+
+        # Ensure all database connections are closed before we attempt to import
+        # as this will need to drop the database.
+        for connection in connections.all():
+            connection.close()
+
+        # Run the import
+        process = run_command(
+            "devdata_import",
+            test_data_dir.name,
+            "--no-input",
+            f"--reset-mode={reset_mode}",
+        )
+        assert_ran_successfully(process)
+
+        # Unblock the database so that we can resume accessing it. This will be
+        # a different actual database on disk at this point, as the import will
+        # have recreated it. We do this before assertions so that we've
+        # restored database access for later tests if needed.
+        with django_db_blocker.unblock():
+            self.assert_on_imported_data()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,7 @@ import datetime
 
 import pytest
 from django.db import connections
+from django.db.migrations.recorder import MigrationRecorder
 from polls.models import Choice, Question
 from test_infrastructure import DevdataTestBase
 from test_infrastructure.utils import assert_ran_successfully, run_command
@@ -110,6 +111,12 @@ class TestPollsBasic(DevdataTestBase):
             votes=2,
         )
 
+        recorder = MigrationRecorder(connections["default"])
+        recorder.record_applied("fake-app", "0001-fake-migration")
+        assert recorder.applied_migrations().keys() == {
+            ("fake-app", "0001-fake-migration"),
+        }
+
         # Ensure all database connections are closed before we attempt to import
         # as this will need to drop the database.
         for connection in connections.all():
@@ -130,3 +137,8 @@ class TestPollsBasic(DevdataTestBase):
         # restored database access for later tests if needed.
         with django_db_blocker.unblock():
             self.assert_on_imported_data()
+
+        recorder = MigrationRecorder(connections["default"])
+        assert recorder.applied_migrations().keys() == {
+            ("auth", "0001_initial"),
+        }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -90,6 +90,7 @@ class TestPollsBasic(DevdataTestBase):
         test_data_dir,
         default_export_data,
         django_db_blocker,
+        ensure_migrations_table,
     ):
         self.dump_data_for_import(self.get_original_data(), test_data_dir)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -65,6 +65,8 @@ class TestPollsBasic(DevdataTestBase):
         assert orig_choices.issubset(exported_choices)
 
     def assert_on_imported_data(self):
-        assert Question.objects.count() == 2
+        assert sorted(
+            Question.objects.values_list("question_text", flat=True)
+        ) == ["Test 1", "Test 2"]
         assert Choice.objects.count() == 3
         assert Question.objects.get(pk=101).choice_set.count() == 2

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import datetime
 
 import pytest
@@ -142,3 +143,91 @@ class TestPollsBasic(DevdataTestBase):
         assert recorder.applied_migrations().keys() == {
             ("auth", "0001_initial"),
         }
+
+    def test_import_over_existing_data_reset_mode_none(
+        self,
+        test_data_dir,
+        default_export_data,
+        django_db_blocker,
+        ensure_migrations_table,
+    ):
+        self.dump_data_for_import(self.get_original_data(), test_data_dir)
+
+        # A slightly extended migration history to explore conflicts & overwriting
+        (test_data_dir / "migrations.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "app": "auth",
+                        "name": "0001_initial",
+                        "applied": "2023-01-01T12:00:00.000Z",
+                    },
+                    {
+                        "app": "exported_only",
+                        "name": "0001_initial",
+                        "applied": "2023-01-01T12:00:00.000Z",
+                    },
+                ],
+            ),
+        )
+
+        question = Question.objects.create(
+            question_text="Do you like jam?",
+            pub_date=datetime.datetime.now(datetime.timezone.utc),
+        )
+        Choice.objects.create(
+            question=question,
+            choice_text="Yes",
+            votes=2,
+        )
+        Choice.objects.create(
+            pk=103,  # conflicts with data to be imported
+            question=question,
+            choice_text="No",
+            votes=2,
+        )
+
+        recorder = MigrationRecorder(connections["default"])
+        recorder.record_applied("fake-app", "0001-fake-migration")
+        recorder.record_applied("auth", "0001_initial")
+        assert sorted(recorder.migration_qs.values_list("app", "name")) == [
+            ("auth", "0001_initial"),
+            ("fake-app", "0001-fake-migration"),
+        ]
+
+        # Ensure all database connections are closed before we attempt to import
+        # as this will need to drop the database.
+        for connection in connections.all():
+            connection.close()
+
+        # Run the import
+        process = run_command(
+            "devdata_import",
+            test_data_dir.name,
+            "--no-input",
+            "--reset-mode=none",
+        )
+        assert_ran_successfully(process)
+
+        # Unblock the database so that we can resume accessing it. This will be
+        # a different actual database on disk at this point, as the import will
+        # have recreated it. We do this before assertions so that we've
+        # restored database access for later tests if needed.
+        with django_db_blocker.unblock():
+            assert sorted(
+                Question.objects.values_list("question_text", flat=True),
+            ) == ["Do you like jam?", "Test 1", "Test 2"]
+            assert Choice.objects.count() == 4
+            assert Question.objects.get(pk=101).choice_set.count() == 2
+
+        recorder = MigrationRecorder(connections["default"])
+        assert sorted(recorder.migration_qs.values_list("app", "name")) == [
+            # Note: we end up with `auth.0001_initial` in the migrations table
+            # twice as the model has no unique constraint and this is pretty
+            # much what the user asked for -- that we import the new data over
+            # the top.
+            ("auth", "0001_initial"),
+            ("auth", "0001_initial"),
+            ("exported_only", "0001_initial"),
+            ("fake-app", "0001-fake-migration"),
+        ]

--- a/tests/test_infrastructure/base.py
+++ b/tests/test_infrastructure/base.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Iterable, Set
 import pytest
 from django.core import serializers
 from django.db import connections, transaction
-from django.db.migrations.recorder import MigrationRecorder
 
 from devdata.reset_modes import MODES
 from devdata.utils import to_app_model_label, to_model
@@ -111,10 +110,7 @@ class DevdataTestBase:
 
     # Test structure
 
-    def test_export(self, test_data_dir):
-        for connection in connections.all():
-            MigrationRecorder(connection).ensure_schema()
-
+    def test_export(self, test_data_dir, ensure_migrations_table):
         with transaction.atomic():
             data = json.dumps(self.get_original_data())
             objects = serializers.deserialize("json", data)
@@ -152,6 +148,7 @@ class DevdataTestBase:
         test_data_dir,
         default_export_data,
         django_db_blocker,
+        ensure_migrations_table,
     ):
         self.dump_data_for_import(self.get_original_data(), test_data_dir)
 

--- a/tests/test_infrastructure/base.py
+++ b/tests/test_infrastructure/base.py
@@ -155,20 +155,6 @@ class DevdataTestBase:
     ):
         self.dump_data_for_import(self.get_original_data(), test_data_dir)
 
-        # Ensure we have migrations history to import to validate that the
-        # import of such data actually works.
-        (test_data_dir / "migrations.json").write_text(
-            json.dumps(
-                [
-                    {
-                        "app": "auth",
-                        "name": "0001_initial",
-                        "applied": "2023-01-01T12:00:00.000Z",
-                    },
-                ],
-            ),
-        )
-
         # Ensure all database connections are closed before we attempt to import
         # as this will need to drop the database.
         for connection in connections.all():

--- a/tests/test_infrastructure/base.py
+++ b/tests/test_infrastructure/base.py
@@ -8,6 +8,7 @@ from django.core import serializers
 from django.db import connections, transaction
 from django.db.migrations.recorder import MigrationRecorder
 
+from devdata.reset_modes import MODES
 from devdata.utils import to_app_model_label, to_model
 
 from .utils import assert_ran_successfully, run_command
@@ -105,8 +106,10 @@ class DevdataTestBase:
 
         self.assert_on_exported_data(exported_data)
 
+    @pytest.mark.parametrize("reset_mode", MODES.keys())
     def test_import(
         self,
+        reset_mode,
         test_data_dir,
         default_export_data,
         django_db_blocker,
@@ -156,6 +159,7 @@ class DevdataTestBase:
             "devdata_import",
             test_data_dir.name,
             "--no-input",
+            f"--reset-mode={reset_mode}",
         )
         assert_ran_successfully(process)
 

--- a/tests/test_sequences_extra.py
+++ b/tests/test_sequences_extra.py
@@ -5,6 +5,8 @@ from django.db import connection, connections
 from django.db.migrations.recorder import MigrationRecorder
 from test_infrastructure import assert_ran_successfully, run_command
 
+from devdata.reset_modes import MODES
+
 
 @pytest.mark.django_db(transaction=True)
 class TestPostgresSequences:
@@ -85,7 +87,14 @@ class TestPostgresSequences:
         }
         assert exported_data == [expected_data]
 
-    def test_import(self, test_data_dir, default_export_data, cleanup_database):
+    @pytest.mark.parametrize("reset_mode", MODES.keys())
+    def test_import(
+        self,
+        reset_mode,
+        test_data_dir,
+        default_export_data,
+        cleanup_database,
+    ):
         test_data_dir.mkdir(parents=True, exist_ok=True)
         (test_data_dir / "postgres-sequences.json").write_text(
             json.dumps([self.SAMPLE_DATA]),
@@ -101,6 +110,7 @@ class TestPostgresSequences:
             "devdata_import",
             test_data_dir.name,
             "--no-input",
+            f"--reset-mode={reset_mode}",
         )
         assert_ran_successfully(process)
 

--- a/tests/test_sequences_extra.py
+++ b/tests/test_sequences_extra.py
@@ -2,7 +2,6 @@ import json
 
 import pytest
 from django.db import connection, connections
-from django.db.migrations.recorder import MigrationRecorder
 from test_infrastructure import assert_ran_successfully, run_command
 
 from devdata.reset_modes import MODES
@@ -22,10 +21,12 @@ class TestPostgresSequences:
         "last_value": 14,
     }
 
-    def test_export(self, test_data_dir, cleanup_database):
-        for conn in connections.all():
-            MigrationRecorder(conn).ensure_schema()
-
+    def test_export(
+        self,
+        test_data_dir,
+        cleanup_database,
+        ensure_migrations_table,
+    ):
         with connection.cursor() as cursor:
             cursor.execute(
                 """
@@ -55,10 +56,12 @@ class TestPostgresSequences:
 
         assert exported_data == [self.SAMPLE_DATA]
 
-    def test_export_unused_sequence(self, test_data_dir, cleanup_database):
-        for conn in connections.all():
-            MigrationRecorder(conn).ensure_schema()
-
+    def test_export_unused_sequence(
+        self,
+        test_data_dir,
+        cleanup_database,
+        ensure_migrations_table,
+    ):
         with connection.cursor() as cursor:
             cursor.execute(
                 """


### PR DESCRIPTION
This introduces support for "reset modes"[^1] -- different approaches for ensuring a clean database before importing the fresh data. Initial support is for three modes:

- `drop-database`: the default; drops the database & re-creates it.
- `drop-tables`: drops the tables the Django codebase is aware of, useful if the Django database user doesn't have access to drop the entire database.
- `none`: no attempt to reset the database, useful if the user has already manually configured the database or otherwise wants more control over setup.

Using the second of these in a staging-type environment is the main motivation for this change.

This PR also updates the existing `PostgresSequences` extra to cope with a sequence of a given name already being present by overwriting it. This doesn't feel like the best solution (the result if the import somehow lists the same sequence twice may be unexpected), but seemed probably the simplest for now given what devdata is typically used for.

Review by commit may be useful, they're in a hopefully sensible order for that.

Testing is achieved by adding reset modes to all existing import tests as well as creating a few more. I've also tested this against the use-case I originally had (importing against an existing database part of a staging environment).

Fixes https://github.com/danpalmer/django-devdata/issues/23

TODO:
- [x] :lady_beetle: ensure the django migrations table is cleared when using the `drop-tables` mode -> tested & fixed in 42271396d13b9448c8545126dcf45f6dc894e1b5
- [x] validate behaviour of `none` when importing over the top of an existing matching schema -> test demonstrating result in 84a2b03b6e6dfe857f360a093664bee49566abf6

[^1]: This doesn't feel like the best name, however "strategies" is already taken in this project and I didn't want to confuse that. Open to changing this if we can come up with something better!
