### PR TITLE
Drop support for legacy Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["3.2", "4.0", "4.1"]
         exclude:
           # Python 3.11 is not supported until Django 4.1
@@ -19,12 +19,6 @@ jobs:
             django-version: "3.2"
           - python-version: "3.11"
             django-version: "4.0"
-
-          # Python 3.7 is not supported beyond Django 3.2
-          - python-version: "3.7"
-            django-version: "4.0"
-          - python-version: "3.7"
-            django-version: "4.1"
 
     services:
       postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7"
+python = ">=3.8"
 tqdm = ">=4.0.0"
 Faker = ">=5.0.0"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 isolated_build = true
-envlist = py{37,38,39,310,311}-django{32,40,41}
+envlist = py{38,39,310,311}-django{32,40,41}
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
@@ -19,9 +18,6 @@ django-version =
 [testenv]
 whitelist_externals = poetry
 deps =
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2


### PR DESCRIPTION
This will simplify adding support for Django 5.