### PR TITLE
Introduce a CI step to validate dependency locks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,26 @@ jobs:
       - name: Lint
         run: |
           poetry run flake8 . --jobs=auto --format=github
+
+  validate-dependencies:
+    name: Check dependency locks
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Set up Poetry
+        uses: abatilo/actions-poetry@v2.1.5
+        with:
+          poetry-version: 1.3.2
+
+      - uses: PeterJCLaw/validate-generated-files@v1
+        with:
+          command: poetry lock --no-update
+          files: poetry.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: 1.3.2
+          poetry-version: 1.7.1
 
       - name: Set up dependencies
         run: poetry install
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: 1.3.2
+          poetry-version: 1.7.1
 
       - name: Install dependencies
         run: |
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: 1.3.2
+          poetry-version: 1.7.1
 
       - uses: PeterJCLaw/validate-generated-files@v1
         with:


### PR DESCRIPTION
Observe that this previously failed due to CI using an older version of `poetry`, which was potentially also likely to confuse developers who might reference CI to know which version to use locally. Following an update to the CI config, this now passes as would be expected.